### PR TITLE
Check stack health

### DIFF
--- a/check_rancher_containers.ini
+++ b/check_rancher_containers.ini
@@ -20,5 +20,7 @@ service_list = [ "item1", "item2" ]
 # if running on a host that is also an agent, can specify to run `docker stats`
 # to report large memory containers on the host
 rancher_hostid = 
+# optional flag to check stack health (default false)
+test_stack_health = 0
 # optional flag to test creating a new service (default false)
 test_create_new = 0

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -146,7 +146,7 @@ def process_section(conf, section):
 			stackState = 1
 			stackStateTxt = 'WARNING'
 
-		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState]')
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 
 # if on a host running containers, check their resources
 # assume only one instance per service

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -142,11 +142,11 @@ def process_section(conf, section):
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
-		if stackData[myStack]['healthState'] == 'unhealthy':
+		if stackData[myStack]['healthState'] == 'degraded':
 			stackState = 1
 			stackStateTxt = 'WARNING'
 
-		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt )
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState]')
 
 # if on a host running containers, check their resources
 # assume only one instance per service

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -135,6 +135,19 @@ def process_section(conf, section):
 			print (str(serviceState) + ' ' + envname + '_' + stackname + '_' + svc['name'] + ' - ' + serviceStateTxt + ' running instances: ' + str(svc['currentScale']))
 	#	    print svc['healthState']
 
+	if (conf.has_option(section,'test_stack_health') and conf.getboolean(section,'test_stack_health') is True):
+		stackState = 3
+		stackStateTxt = 'UNKNOWN'
+
+		if stackData[myStack]['healthState'] == 'healthy':
+			stackState = 0
+			stackStateTxt = 'OK'
+		if stackData[myStack]['healthState'] == 'unhealthy':
+			stackState = 1
+			stackStateTxt = 'WARNING'
+
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt )
+
 # if on a host running containers, check their resources
 # assume only one instance per service
 ### this part needs lots of work


### PR DESCRIPTION
Optionally check the health of the entire stack, throw a warning if not healthy.  (In general a stack should be healthy if all its services are, but we haven't looked at this thoroughly.)