### PR TITLE
Stack health age

### DIFF
--- a/check_rancher_containers.ini
+++ b/check_rancher_containers.ini
@@ -24,3 +24,8 @@ rancher_hostid =
 test_stack_health = 0
 # optional flag to test creating a new service (default false)
 test_create_new = 0
+# dir to touch a status file for a healthy stack (default undefined, does not try to touch status file)
+# (file name is like 'envname_stackname_stackHealth' so risk of name clash is very low)
+stack_health_dir = /var/lib/check_mk_agent
+# option to raise a critical alert if status file is older than this (in seconds) (default undefined)
+stack_health_age = 600

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -157,7 +157,8 @@ def process_section(conf, section):
 			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
-			    pprint (stackPath.stat())
+			    pprint (stackPath.stat().st_mtime)
+			    pprint (time.time.gmtime())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -162,7 +162,7 @@ def process_section(conf, section):
 			    # if missing, don't do anything?
 			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
 			        stackState = 2
-			        stackStateTxt = 'CRITICAL (state ' + time.time - stackPath.stat().st_mtime + 'sec old) '
+			        stackStateTxt = 'CRITICAL (state ' + str(time.time() - stackPath.stat().st_mtime) + 'sec old) '
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -157,7 +157,7 @@ def process_section(conf, section):
 			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
-			    print stackPath.stat()
+			    pprint (stackPath.stat())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -162,7 +162,7 @@ def process_section(conf, section):
 			    # if missing, don't do anything?
 			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
 			        stackState = 2
-			        stackStateTxt = 'CRITICAL'
+			        stackStateTxt = 'CRITICAL (state ' + str(time.time - stackPath.stat().st_mtime) + 'sec old')
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -144,7 +144,7 @@ def process_section(conf, section):
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
-			if (conf.has_option(section,'stack_health_dir'):
+			if (conf.has_option(section,'stack_health_dir')):
 			    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth
 			    pathlib.Path(stackHealthFile).touch()
 		if stackData[myStack]['healthState'] == 'degraded':

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -13,6 +13,8 @@ import configparser
 import json
 import subprocess
 import time
+# this requires python 3.4
+import pathlib
 from pprint import pprint
 
 parser = argparse.ArgumentParser(description='Check the status of Rancher agents and their containers.')
@@ -142,6 +144,9 @@ def process_section(conf, section):
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
+			if (conf.has_option(section,'stack_health_dir'):
+			    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth
+			    pathlib.Path(stackHealthFile).touch()
 		if stackData[myStack]['healthState'] == 'degraded':
 			stackState = 1
 			stackStateTxt = 'WARNING'

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -162,7 +162,7 @@ def process_section(conf, section):
 			    # if missing, don't do anything?
 			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
 			        stackState = 2
-			        stackStateTxt = 'CRITICAL (state ' + str(time.time - stackPath.stat().st_mtime) + 'sec old) '
+			        stackStateTxt = 'CRITICAL (state ' + time.time - stackPath.stat().st_mtime + 'sec old) '
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -146,7 +146,7 @@ def process_section(conf, section):
 		    stackPath = pathlib.Path(stackHealthFile)
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
-		    if (! stackPath.exists()):
+		    if (not stackPath.exists()):
 		        stackPath.touch()
 			
 		if stackData[myStack]['healthState'] == 'healthy':

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -146,7 +146,7 @@ def process_section(conf, section):
 		    stackPath = pathlib.Path(stackHealthFile)
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
-		    if (!stackPath.exists()):
+		    if (! stackPath.exists()):
 		        stackPath.touch()
 			
 		if stackData[myStack]['healthState'] == 'healthy':

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -145,7 +145,7 @@ def process_section(conf, section):
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
-			    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth
+			    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
 			    pathlib.Path(stackHealthFile).touch()
 		if stackData[myStack]['healthState'] == 'degraded':
 			stackState = 1

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -158,7 +158,7 @@ def process_section(conf, section):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
 			    time.sleep(5)
-			    pprint (stackPath.stat().st_mtime - time.time())
+			    pprint (time.time() - stackPath.stat().st_mtime)
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -162,7 +162,7 @@ def process_section(conf, section):
 			    # if missing, don't do anything?
 			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
 			        stackState = 2
-			        stackStateTxt = 'CRITICAL (state ' + str(time.time - stackPath.stat().st_mtime) + 'sec old')
+			        stackStateTxt = 'CRITICAL (state ' + str(time.time - stackPath.stat().st_mtime) + 'sec old) '
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -141,15 +141,23 @@ def process_section(conf, section):
 		stackState = 3
 		stackStateTxt = 'UNKNOWN'
 
+		if (conf.has_option(section,'stack_health_dir')):
+		    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
+		    stackPath = pathlib.Path(stackHealthFile)
+
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
-			    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
-			    pathlib.Path(stackHealthFile).touch()
-		if stackData[myStack]['healthState'] == 'degraded':
+			    stackPath.touch()
+#		if stackData[myStack]['healthState'] == 'degraded':
+		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 1
 			stackStateTxt = 'WARNING'
+			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
+			    # check age, if too old, make state critical
+			    # if missing, don't do anything?
+			    print stackPath.stat()
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -154,7 +154,9 @@ def process_section(conf, section):
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
 			    stackPath.touch()
-		if stackData[myStack]['healthState'] == 'degraded':
+#		if stackData[myStack]['healthState'] == 'degraded':
+		# this may be too broad, but let's see if it's a problem
+		else:
 			stackState = 1
 			stackStateTxt = 'WARNING'
 			if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -158,7 +158,7 @@ def process_section(conf, section):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
 			    pprint (stackPath.stat().st_mtime)
-			    pprint (time.time.gmtime())
+			    pprint (time.gmtime())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -158,7 +158,7 @@ def process_section(conf, section):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
 			    pprint (stackPath.stat().st_mtime)
-			    pprint (time.gmtime())
+			    pprint (time.time())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -157,6 +157,7 @@ def process_section(conf, section):
 			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
+			    time.sleep(5)
 			    pprint (stackPath.stat().st_mtime - time.time())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -157,11 +157,12 @@ def process_section(conf, section):
 		if stackData[myStack]['healthState'] == 'degraded':
 			stackState = 1
 			stackStateTxt = 'WARNING'
-			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
+			if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
-			    time.sleep(5)
-			    pprint (time.time() - stackPath.stat().st_mtime)
+			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
+			        stackState = 2
+			        stackStateTxt = 'CRITICAL'
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -144,14 +144,17 @@ def process_section(conf, section):
 		if (conf.has_option(section,'stack_health_dir')):
 		    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
 		    stackPath = pathlib.Path(stackHealthFile)
-
+		    # make sure the file exists, in case stack has never been healthy
+		    # (should also error immediately if a bad path is provided in the config file)
+		    unless (stackPath.exists()):
+		        stackPath.touch()
+			
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
 			    stackPath.touch()
-#		if stackData[myStack]['healthState'] == 'degraded':
-		if stackData[myStack]['healthState'] == 'healthy':
+		if stackData[myStack]['healthState'] == 'degraded':
 			stackState = 1
 			stackStateTxt = 'WARNING'
 			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -162,7 +162,7 @@ def process_section(conf, section):
 			    # if missing, don't do anything?
 			    if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
 			        stackState = 2
-			        stackStateTxt = 'CRITICAL (state ' + str(time.time() - stackPath.stat().st_mtime) + 'sec old) '
+			        stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -146,7 +146,7 @@ def process_section(conf, section):
 		    stackPath = pathlib.Path(stackHealthFile)
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
-		    unless (stackPath.exists()):
+		    if (!stackPath.exists()):
 		        stackPath.touch()
 			
 		if stackData[myStack]['healthState'] == 'healthy':

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -157,8 +157,7 @@ def process_section(conf, section):
 			if (conf.has_option(section,'stack_health_dir') and stackPath.exists()):
 			    # check age, if too old, make state critical
 			    # if missing, don't do anything?
-			    pprint (stackPath.stat().st_mtime)
-			    pprint (time.time())
+			    pprint (stackPath.stat().st_mtime - time.time())
 
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 


### PR DESCRIPTION
If both stack_health_dir and stack_health_age are defined, then alert CRITICAL instead of WARNING if the stack health file is too old.