### PR TITLE
DEVOPS-1973 improve stack health reporting

### DIFF
--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -185,7 +185,11 @@ def process_section(conf, section):
 					
 
 			cursor = conn.cursor()
-			cursor.execute('SELECT serviceName FROM badServices')
+			query = "SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now','-" + conf[section]['stack_health_age'] + " seconds' ))"
+#			print (query)
+			cursor.execute(query)
+
+			cursor.execute('SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now ')
 			badServices = cursor.fetchall()
 			if (len(badServices) == 0):
 				# all services now OK, so assume stack OK

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -149,7 +149,7 @@ def process_section(conf, section):
 			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackHealthFile)
-				conn.execute('CREATE TABLE badServices (serviceName text)')
+				conn.execute('CREATE TABLE badServices (serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP)')
 				conn.close()
 
 		conn = sqlite3.connect(stackHealthFile)
@@ -158,11 +158,17 @@ def process_section(conf, section):
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
+# just assume all services are healthy if stack is, and delete them from the db
 				conn.execute('DELETE FROM badServices')
 				conn.commit()
 			
-#		if stackData[myStack]['healthState'] == 'degraded':
 		# this may be too broad, but let's see if it's a problem
+# plan: look through services in stack
+# if service healthy, delete from table
+# if service unhealthy, look for it in table
+# if not in table, insert it
+# if in table, leave it
+# after all services in stack are done, look through table, if any service timestamp is too old, throw alert
 		else:
 			stackState = 1
 			stackStateTxt = 'WARNING'

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -160,15 +160,13 @@ def process_section(conf, section):
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
-# just assume all services are healthy if stack is, and delete them from the db
+# just assume all services are healthy if stack is, and delete all bad services from the db
 				conn.execute('DELETE FROM badServices')
 				conn.commit()
 
 # plan: look through services in stack
 # if service healthy, delete from table
-# if service unhealthy, look for it in table
-# if not in table, insert it
-# if in table, leave it
+# if service unhealthy, insert or ignore (ignore preserves original timestamp)
 # after all services in stack are done, look through table, if any service timestamp is too old, throw alert
 		else:
 			# we're trolling this again, meh
@@ -198,6 +196,8 @@ def process_section(conf, section):
 				stackState = 1
 				stackStateTxt = 'WARNING'
 				stackExtraTxt = 'bad services: ' + ' '.join([ t[0] for t in badServices])
+
+# ideally, have something here to set state CRITICAL if age is even older (maybe 2x what's in the ini file?)
 
 #				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			# check age, if too old, make state critical

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -143,10 +143,10 @@ def process_section(conf, section):
 		stackStateTxt = 'UNKNOWN'
 
 		if (conf.has_option(section,'stack_health_dir')):
-		    stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
-		    stackPath = pathlib.Path(stackHealthFile)
-		    # make sure the file exists, in case stack has never been healthy
-		    # (should also error immediately if a bad path is provided in the config file)
+			stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
+			stackPath = pathlib.Path(stackHealthFile)
+			# make sure the file exists, in case stack has never been healthy
+			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackPath)
 				cursor = conn.cursor()

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -200,7 +200,7 @@ def process_section(conf, section):
 #			print (query)
 				cursor.execute(query)
 				reallyBadServices = cursor.fetchall()
-				if (len(reallyBadServices) == 0):
+				if (len(reallyBadServices) > 0):
 					stackState = 2
 					stackStateTxt = 'CRITICAL'
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -180,7 +180,7 @@ def process_section(conf, section):
 					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
 					conn.commit()
 				else:
-					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
+					conn.execute('INSERT OR IGNORE INTO badServices (serviceId, serviceName) VALUES ( ?,?)', [ healthSvc['id'] healthSvc['name']] )
 					conn.commit()
 					
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -173,7 +173,7 @@ def process_section(conf, section):
 			for service in stackData[myStack]['serviceIds']:
 				serviceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
 				svc=serviceReq.json()
-				print svc['healthState']
+				print (svc['healthState'])
 
 			stackState = 1
 			stackStateTxt = 'WARNING'

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -150,7 +150,7 @@ def process_section(conf, section):
 			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackHealthFile)
-				conn.execute('CREATE TABLE badServices (serviceId TEXT, serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP) PRIMARY KEY (serviceId)')
+				conn.execute('CREATE TABLE badServices (serviceId TEXT PRIMARY KEY, serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP)')
 				conn.close()
 
 		conn = sqlite3.connect(stackHealthFile)

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -173,7 +173,7 @@ def process_section(conf, section):
 			for serviceId in stackData[myStack]['serviceIds']:
 				healthServiceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
 				healthSvc=healthServiceReq.json()
-				print (healthSvc['id'] + ' ' + healthSvc['healthState'])
+#				print (healthSvc['id'] + ' ' + healthSvc['healthState'])
 				if (healthSvc['healthState'] == 'healthy' or healthSvc['healthState'] == 'started-once'):
 					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
 					conn.commit()

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -13,6 +13,7 @@ import configparser
 import json
 import subprocess
 import time
+import sqlite3
 # this requires python 3.4
 import pathlib
 from pprint import pprint
@@ -147,7 +148,9 @@ def process_section(conf, section):
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
 		    if (not stackPath.exists()):
-		        stackPath.touch()
+		        conn = sqlite3.connect(stackPath)
+			cursor = conn.cursor()
+			cursor.execute('CREATE TABLE badServices (serviceName text)')
 			
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -148,7 +148,7 @@ def process_section(conf, section):
 			# make sure the file exists, in case stack has never been healthy
 			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
-				conn = sqlite3.connect(stackPath)
+				conn = sqlite3.connect(stackHealthFile)
 				cursor = conn.cursor()
 				cursor.execute('CREATE TABLE badServices (serviceName text)')
 			

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -199,7 +199,7 @@ def process_section(conf, section):
 						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
-		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + ' ' + stackExtraTxt)
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + ' ; ' + stackExtraTxt)
 
 # if on a host running containers, check their resources
 # assume only one instance per service

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -180,7 +180,7 @@ def process_section(conf, section):
 					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
 					conn.commit()
 				else:
-					conn.execute('INSERT OR IGNORE INTO badServices (serviceId, serviceName) VALUES ( ?,?)', [ healthSvc['id'] healthSvc['name']] )
+					conn.execute('INSERT OR IGNORE INTO badServices (serviceId, serviceName) VALUES (?,?)', [ healthSvc['id'], healthSvc['name']] )
 					conn.commit()
 					
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -143,7 +143,7 @@ def process_section(conf, section):
 		stackStateTxt = 'UNKNOWN'
 
 		if (conf.has_option(section,'stack_health_dir')):
-			stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth'
+			stackHealthFile = conf[section]['stack_health_dir'] + '/' + envname + '_' + stackname + '_stackHealth.db'
 			stackPath = pathlib.Path(stackHealthFile)
 			# make sure the file exists, in case stack has never been healthy
 			# (should also error immediately if a bad path is provided in the config file)

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -199,7 +199,7 @@ def process_section(conf, section):
 				stackStateTxt = 'WARNING'
 				stackExtraTxt = 'bad services: ' + ' '.join([ t[0] for t in badServices])
 
-				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
+#				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			# check age, if too old, make state critical
 			# if missing, don't do anything?
 			# not using, soon to remove

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -149,17 +149,17 @@ def process_section(conf, section):
 			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackHealthFile)
-				cursor = conn.cursor()
-				cursor.execute('CREATE TABLE badServices (serviceName text)')
+				conn.execute('CREATE TABLE badServices (serviceName text)')
+				conn.close()
 
 		conn = sqlite3.connect(stackHealthFile)
-		cursor = conn.cursor()
 
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
-				cursor.execute('DELETE FROM badServices')
+				conn.execute('DELETE FROM badServices')
+				conn.commit()
 			
 #		if stackData[myStack]['healthState'] == 'degraded':
 		# this may be too broad, but let's see if it's a problem
@@ -173,6 +173,7 @@ def process_section(conf, section):
 			        stackState = 2
 			        stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
+		conn.close()
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])
 
 # if on a host running containers, check their resources

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -187,11 +187,11 @@ def process_section(conf, section):
 				stackState = 1
 				stackStateTxt = 'WARNING'
 				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
-				    # check age, if too old, make state critical
-			    		# if missing, don't do anything?
-			    	if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
-			        	stackState = 2
-			        	stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
+			# check age, if too old, make state critical
+			# if missing, don't do anything?
+				if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
+					stackState = 2
+					stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -150,7 +150,7 @@ def process_section(conf, section):
 			# (should also error immediately if a bad path is provided in the config file)
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackHealthFile)
-				conn.execute('CREATE TABLE badServices (serviceId TEXT, serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP)')
+				conn.execute('CREATE TABLE badServices (serviceId TEXT, serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP) PRIMARY KEY (serviceId)')
 				conn.close()
 
 		conn = sqlite3.connect(stackHealthFile)
@@ -178,6 +178,10 @@ def process_section(conf, section):
 				if (healthSvc['healthState'] == 'healthy' or healthSvc['healthState'] == 'started-once'):
 					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
 					conn.commit()
+				else:
+					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
+					conn.commit()
+					
 
 			cursor = conn.cursor()
 			cursor.execute('SELECT serviceName FROM badServices')

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -202,9 +202,10 @@ def process_section(conf, section):
 				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			# check age, if too old, make state critical
 			# if missing, don't do anything?
-					if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
-						stackState = 2
-						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
+			# not using, soon to remove
+#					if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
+#						stackState = 2
+#						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + ' ; ' + stackExtraTxt)

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -174,8 +174,9 @@ def process_section(conf, section):
 				healthServiceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
 				healthSvc=healthServiceReq.json()
 				print (healthSvc['id'] + ' ' + healthSvc['healthState'])
-				conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
-				conn.commit()
+				if (healthSvc['healthState'] == 'healthy' or healthSvc['healthState'] == 'started-once'):
+					conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
+					conn.commit()
 
 			cursor = conn.cursor()
 			cursor.execute('SELECT * FROM badServices')

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -148,7 +148,7 @@ def process_section(conf, section):
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
 		    if (not stackPath.exists()):
-		        conn = sqlite3.connect(stackPath)
+			conn = sqlite3.connect(stackPath)
 			cursor = conn.cursor()
 			cursor.execute('CREATE TABLE badServices (serviceName text)')
 			

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -170,7 +170,7 @@ def process_section(conf, section):
 # after all services in stack are done, look through table, if any service timestamp is too old, throw alert
 		else:
 			# we're trolling this again, meh
-			for service in stackData[myStack]['serviceIds']:
+			for serviceId in stackData[myStack]['serviceIds']:
 				healthServiceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
 				healthSvc=healthServiceReq.json()
 				print (healthSvc['id'] + ' ' + healthSvc['healthState'])

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -189,7 +189,7 @@ def process_section(conf, section):
 			else:
 				stackState = 1
 				stackStateTxt = 'WARNING'
-				stackExtraTxt = 'bad services: ' + ' '.join(badServices)
+				stackExtraTxt = 'bad services: ' + ' '.join([ t[0] for t in badServices])
 
 				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			# check age, if too old, make state critical
@@ -199,7 +199,7 @@ def process_section(conf, section):
 						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
-		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + stackExtraTxt)
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + ' ' + stackExtraTxt)
 
 # if on a host running containers, check their resources
 # assume only one instance per service

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -151,12 +151,16 @@ def process_section(conf, section):
 				conn = sqlite3.connect(stackHealthFile)
 				cursor = conn.cursor()
 				cursor.execute('CREATE TABLE badServices (serviceName text)')
-			
+
+		conn = sqlite3.connect(stackHealthFile)
+		cursor = conn.cursor()
+
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0
 			stackStateTxt = 'OK'
 			if (conf.has_option(section,'stack_health_dir')):
-			    stackPath.touch()
+				cursor.execute('DELETE FROM badServices')
+			
 #		if stackData[myStack]['healthState'] == 'degraded':
 		# this may be too broad, but let's see if it's a problem
 		else:

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -171,10 +171,10 @@ def process_section(conf, section):
 		else:
 			# we're trolling this again, meh
 			for service in stackData[myStack]['serviceIds']:
-				serviceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
-				svc=serviceReq.json()
-				print (svc['healthState'])
-				conn.execute('DELETE FROM badServices WHERE serviceId = ?',svc['id'])
+				healthServiceReq=session.get(urlbase+'/v2-beta/projects/' + envid + '/services/' + serviceId, auth=(username,password))
+				healthSvc=healthServiceReq.json()
+				print (healthSvc['id'] + ' ' + healthSvc['healthState'])
+				conn.execute('DELETE FROM badServices WHERE serviceId = ?', [ healthSvc['id'] ] )
 				conn.commit()
 
 			cursor = conn.cursor()

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -195,7 +195,7 @@ def process_section(conf, section):
 			else:
 				stackState = 1
 				stackStateTxt = 'WARNING'
-				stackExtraTxt = 'bad services: ' + ' '.join([ t[0] for t in badServices])
+				stackExtraTxt = ' ; bad services: ' + ' '.join([ t[0] for t in badServices])
 
 # ideally, have something here to set state CRITICAL if age is even older (maybe 2x what's in the ini file?)
 
@@ -208,7 +208,7 @@ def process_section(conf, section):
 #						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
-		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + ' ; ' + stackExtraTxt)
+		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'] + stackExtraTxt)
 
 # if on a host running containers, check their resources
 # assume only one instance per service

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -189,7 +189,6 @@ def process_section(conf, section):
 #			print (query)
 			cursor.execute(query)
 
-			cursor.execute('SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now ')
 			badServices = cursor.fetchall()
 			if (len(badServices) == 0):
 				# all services now OK, so assume stack OK

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -147,10 +147,10 @@ def process_section(conf, section):
 		    stackPath = pathlib.Path(stackHealthFile)
 		    # make sure the file exists, in case stack has never been healthy
 		    # (should also error immediately if a bad path is provided in the config file)
-		    if (not stackPath.exists()):
-			conn = sqlite3.connect(stackPath)
-			cursor = conn.cursor()
-			cursor.execute('CREATE TABLE badServices (serviceName text)')
+			if (not stackPath.exists()):
+				conn = sqlite3.connect(stackPath)
+				cursor = conn.cursor()
+				cursor.execute('CREATE TABLE badServices (serviceName text)')
 			
 		if stackData[myStack]['healthState'] == 'healthy':
 			stackState = 0

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -151,6 +151,7 @@ def process_section(conf, section):
 			if (not stackPath.exists()):
 				conn = sqlite3.connect(stackHealthFile)
 				conn.execute('CREATE TABLE badServices (serviceId TEXT PRIMARY KEY, serviceName TEXT, lastUpdate DATETIME DEFAULT CURRENT_TIMESTAMP)')
+				conn.commit()
 				conn.close()
 
 		conn = sqlite3.connect(stackHealthFile)

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -196,6 +196,13 @@ def process_section(conf, section):
 				stackState = 1
 				stackStateTxt = 'WARNING'
 				stackExtraTxt = ' ; bad services: ' + ' '.join([ t[0] for t in badServices])
+				query = "SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now','-" + (2 * int(conf[section]['stack_health_age'])) + " seconds' ))"
+#			print (query)
+				cursor.execute(query)
+				reallyBadServices = cursor.fetchall()
+				if (len(reallyBadServices) == 0):
+					stackState = 2
+					stackStateTxt = 'CRITICAL'
 
 # ideally, have something here to set state CRITICAL if age is even older (maybe 2x what's in the ini file?)
 

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -189,9 +189,9 @@ def process_section(conf, section):
 				if (conf.has_option(section,'stack_health_dir') and conf.has_option(section,'stack_health_age') and stackPath.exists()):
 			# check age, if too old, make state critical
 			# if missing, don't do anything?
-				if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
-					stackState = 2
-					stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
+					if (time.time() - stackPath.stat().st_mtime > float(conf[section]['stack_health_age'])):
+						stackState = 2
+						stackStateTxt = 'CRITICAL (state ' + str(int(time.time() - stackPath.stat().st_mtime)) + 'sec old)'
 
 		conn.close()
 		print (str(stackState) + ' ' + envname + '_' + stackname + '_stackHealth - ' + stackStateTxt + ' stack health is ' + stackData[myStack]['healthState'])

--- a/check_rancher_services.py
+++ b/check_rancher_services.py
@@ -196,7 +196,7 @@ def process_section(conf, section):
 				stackState = 1
 				stackStateTxt = 'WARNING'
 				stackExtraTxt = ' ; bad services: ' + ' '.join([ t[0] for t in badServices])
-				query = "SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now','-" + (2 * int(conf[section]['stack_health_age'])) + " seconds' ))"
+				query = "SELECT serviceName FROM badServices WHERE (datetime(lastUpdate) < datetime('now','-" + str(2 * int(conf[section]['stack_health_age'])) + " seconds' ))"
 #			print (query)
 				cursor.execute(query)
 				reallyBadServices = cursor.fetchall()


### PR DESCRIPTION
The Rancher 1 API doesn't report stack health very granularly.  There are many legitimate reasons the stack could be degraded but still fine.  (For example, a new service is being spun up right when the health check is done.)

These changes try to track specifically which services (if any) are not healthy when the stack reports unhealthy. If all services are now healthy when checked, assume the stack is too and don't throw an alarm.  And if a service is unhealthy, track it in a sqlite database, and only report the stack unhealthy if there are services that have been unhealthy for longer than the `stack_health_age` parameter.  This avoids the issue of two otherwise healthy services causing the entire stack to seem unhealthy for longer than that parameter.

This PR also removes some old code.